### PR TITLE
use libgsl-dev not libgsl0-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
     libatlas-base-dev \
     libcairo2-dev \
     libhunspell-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libgdal-dev \
     libgeos-dev \
     libgeos-c1v5 \


### PR DESCRIPTION
libgsl0-dev was the very old name which has now been phased out
see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=833050